### PR TITLE
feat: add astroturf vite plugin

### DIFF
--- a/src/vite-plugin.ts
+++ b/src/vite-plugin.ts
@@ -1,0 +1,36 @@
+import { BabelFileResult, transformSync } from '@babel/core';
+
+type ParserPlugin = 'jsx' | 'typescript';
+
+export default () => ({
+  name: 'vite:astroturf',
+  enforce: 'pre',
+  transform: (src: string, id: string): { code: string } => {
+    if (id.includes('node_modules')) {
+      return {
+        code: src,
+      };
+    }
+    const parserPlugins: ParserPlugin[] = [];
+    if (/\.(t|j)sx?$/.test(id)) {
+      parserPlugins.push('jsx');
+    }
+    if (/\.tsx?$/.test(id)) {
+      parserPlugins.push('typescript');
+    }
+    const result: BabelFileResult | null = transformSync(src, {
+      babelrc: false,
+      configFile: false,
+      filename: id,
+      parserOpts: {
+        plugins: parserPlugins,
+      },
+      plugins: ['astroturf/plugin'],
+      sourceMaps: true,
+      sourceFileName: id,
+    });
+    return {
+      code: result?.code || src,
+    };
+  },
+});


### PR DESCRIPTION
Added plugin for [Vite](https://github.com/vitejs/vite)

Currently we have the same problem as in Parcel with saving temporary css files https://github.com/4Catalyzer/astroturf/issues/610

It means that you have to use this plugin with some delete plugin as here https://github.com/4Catalyzer/astroturf/issues/111#issuecomment-674796760