### PR TITLE
fix: css template function should return Record type

### DIFF
--- a/src/runtime/index.d.ts
+++ b/src/runtime/index.d.ts
@@ -12,7 +12,7 @@ declare module 'react' {
   }
 }
 
-export function css(template: TemplateStringsArray, ...args: any[]): string;
+export function css(template: TemplateStringsArray, ...args: any[]): Record<string, string>;
 
 export function stylesheet(
   template: TemplateStringsArray,


### PR DESCRIPTION
After using the astroturf `css` template function, we noticed that the actual output in our code is an `object` rather than a string. 

```
import {css} from 'astroturf'

const styles = css`
  .button {
    padding-top: 16px;
    padding-left: 0;
  }

  .product :global(.ant-form-item-label) {
    flex-basis: auto !important;
  }
`

export default function ProductList(props) {
  console.log('styles -->', styles);
  // other code...

  return (
    <FileUpload
      key={record.id}
      accept=".csv"
      buttonProps={{
        type: 'link',
        loading: isPendingImport,
        className: styles.button,
      }}
      icon={false}
    />
  );
}

```

<img width="554" alt="image" src="https://github.com/astroturfcss/astroturf/assets/23024075/4397607c-9de8-4171-a6ab-271e879c797e">

Therefore, it's necessary to adjust the return type of the `css` template function.